### PR TITLE
Remove Dead Servers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## Elemental 7.1.7
+### Engine
+- Bugfixes in element IDs
+
 ## Elemental 7.1.6
 ### Engine
 - Remember that share button? Well it actually works now!

--- a/game/ts/add-element.ts
+++ b/game/ts/add-element.ts
@@ -17,7 +17,7 @@ import { tutorial1visible, holdingElement, elementContainer, setTutorial1Visible
 // Adds an element and has most element logic
 export function createElement(element: Elem, sourceLocation?: HTMLElement, duringLoad?: boolean): any[] {
   if(!element) return;
-  let escapedId = element.id.replaceAll("\n", "n");
+  let escapedId = String(element.id).replaceAll("\n", "n");
   escapedId = escapedId.replaceAll('"', "'");
   const alreadyExistingDom = document.querySelector(`[data-element="${escapedId}"]`) as HTMLElement;
   

--- a/game/ts/add-element.ts
+++ b/game/ts/add-element.ts
@@ -17,8 +17,8 @@ import { tutorial1visible, holdingElement, elementContainer, setTutorial1Visible
 // Adds an element and has most element logic
 export function createElement(element: Elem, sourceLocation?: HTMLElement, duringLoad?: boolean): any[] {
   if(!element) return;
-  let escapedId = String(element.id).replaceAll("\n", "n");
-  escapedId = escapedId.replaceAll('"', "'");
+  let escapedId = String(element.id).replace(/\n/g, "n");
+  escapedId = escapedId.replace(/"/g, "'");
   const alreadyExistingDom = document.querySelector(`[data-element="${escapedId}"]`) as HTMLElement;
   
   if (alreadyExistingDom) {

--- a/game/ts/server-manager.ts
+++ b/game/ts/server-manager.ts
@@ -23,7 +23,8 @@ export const builtInDevInternalServers = [
   'internal:stress-test-10k',
 ];
 export const builtInThirdPartyServers = [
-  'https://elemental-reborn.tk',      // cannot suggest, need google auth
+  //'https://elemental-reborn.tk',      // cannot suggest, need google auth
+  // elemental reborn commented because it is down and request requires timeout, causing slow load times
 ];
 export const allBuiltInServers = [
   ...builtInOfficialServers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elemental7",
-  "version": "7.1.6",
+  "version": "7.1.7",
   "description": "Modern reboot of the old item combination game.",
   "main": "dist_server/server/index.js",
   "private": true,


### PR DESCRIPTION
Removes Elemetal Reborn because request only stops when it times out, slowing down load times significantly.